### PR TITLE
Updated installer to reflect Composer's plugin API changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
+    "type": "composer-plugin",
     "name": "locomotivemtl/charcoal-composer-installer",
     "description": "Charcoal Module Composer Installer",
-    "keywords":["charcoal", "locomotive", "composer-installer", "module"],
-    "type":"composer-plugin",
+    "keywords": [ "charcoal", "locomotive", "composer-installer", "module" ],
     "authors": [
         {
             "name": "Mathieu Ducharme",
@@ -11,14 +11,10 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "composer-plugin-api": "1.0.0"
+        "composer-plugin-api": "^1.0"
     },
-    "_require-dev":{
-        "phpunit/phpunit": "*",
-        "squizlabs/php_codesniffer": "2.*"
-    },
-    "autoload":{
-        "psr-4":{
+    "autoload": {
+        "psr-4": {
             "Charcoal\\": "src/Charcoal"
         }
     },

--- a/src/Charcoal/Composer/Installer.php
+++ b/src/Charcoal/Composer/Installer.php
@@ -7,36 +7,31 @@ use Composer\Installer\LibraryInstaller;
 
 class Installer extends LibraryInstaller
 {
-    /**
-    * {@inheritDoc}
-    */
-    public function getPackageBasePath(PackageInterface $package)
+    protected $availableTypes = [ 'charcoal-module', 'charcoal-legacy' ];
+
+    public function getInstallPath(PackageInterface $package)
     {
         $type = $package->getType();
-        
-        if($type === 'charcoal-legacy') {
+
+        if ($type === 'charcoal-legacy') {
             return 'www/charcoal/';
         }
-        
+
         $prettyName = $package->getPrettyName();
         if (strpos($prettyName, '/') !== false) {
             list($vendor, $name) = explode('/', $prettyName);
-        } 
-        else {
+        } else {
             $vendor = '';
             $name = $prettyName;
         }
 
-        $module_name = str_replace(['charcoal-', 'module-'], '', $name);
+        $module_name = str_replace([ 'charcoal-', 'module-' ], '', $name);
 
         return 'www/modules/'.$module_name;
     }
 
-    /**
-    * {@inheritDoc}
-    */
     public function supports($packageType)
     {
-        return ('charcoal-module' === $packageType || 'charcoal-legacy' === $packageType);
+        return in_array($packageType, $this->availableTypes);
     }
 }


### PR DESCRIPTION
Changes:
- Requiring the more lenient `^1.0` instead of the strict `1.0.0`;
- Replaced `getPackageBasePath()` with `getInstallPath()` (see [d98b134](https://github.com/composer/composer/commit/d98b134dc3ef7d5bd4b6e37c9621a811f8f1599d))
